### PR TITLE
Fix: remove redundant ref prop from Box props type

### DIFF
--- a/.changeset/fair-kiwis-wink.md
+++ b/.changeset/fair-kiwis-wink.md
@@ -1,0 +1,5 @@
+---
+"classy-ink": patch
+---
+
+Fix: remove redundant ref prop from Box props type

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,9 +1,9 @@
 import { Box as InkBox, type DOMElement } from "ink";
-import { type ComponentPropsWithRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
 
 import { useClassyInk } from "./useClassyInk.js";
 
-export type BoxProps = ComponentPropsWithRef<typeof InkBox> & {
+export type BoxProps = ComponentPropsWithoutRef<typeof InkBox> & {
   class?: string;
 };
 


### PR DESCRIPTION
The `ref` prop is automatically included by the `forwardRef` types.